### PR TITLE
Fix bogus options passed to generated items compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Changes in Ice Builder for MSBuild 5.0.5
+
+- Fix a bug that result in bogus compiler options add to the generated
+  items. See #6
+
+- Fix a bug that result in generated items being compiled twice. See #7
+
 ## Changes in Ice Builder for MSBuild 5.0.4
 
 - Fix a bogus comparison that can result in failure loading projects

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -15,5 +15,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("ZeroC, Inc.")]
 [assembly: AssemblyProduct("Ice Builder")]
 [assembly: AssemblyCopyright("Copyright (c) 2009-2018 ZeroC, Inc.")]
-[assembly: AssemblyVersion("5.0.3")]
+[assembly: AssemblyVersion("5.0.4")]
 [assembly: ComVisibleAttribute(false)]

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -15,5 +15,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("ZeroC, Inc.")]
 [assembly: AssemblyProduct("Ice Builder")]
 [assembly: AssemblyCopyright("Copyright (c) 2009-2018 ZeroC, Inc.")]
-[assembly: AssemblyVersion("5.0.4")]
+[assembly: AssemblyVersion("5.0.5")]
 [assembly: ComVisibleAttribute(false)]

--- a/msbuild/netstandard2.0/icebuilder.msbuild.netstandard2.0.csproj
+++ b/msbuild/netstandard2.0/icebuilder.msbuild.netstandard2.0.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
       <AssemblyName>zeroc.icebuilder.msbuild</AssemblyName>
-      <Version>5.0.4</Version>
+      <Version>5.0.5</Version>
       <OutputPath>../../lib</OutputPath>
       <TargetFramework>netstandard2.0</TargetFramework>
       <TimeStampServer Condition="'$(SIGN_TIMESTAMPSERVER)' == ''">http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>

--- a/msbuild/netstandard2.0/icebuilder.msbuild.netstandard2.0.csproj
+++ b/msbuild/netstandard2.0/icebuilder.msbuild.netstandard2.0.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
       <AssemblyName>zeroc.icebuilder.msbuild</AssemblyName>
-      <Version>5.0.3</Version>
+      <Version>5.0.4</Version>
       <OutputPath>../../lib</OutputPath>
       <TargetFramework>netstandard2.0</TargetFramework>
       <TimeStampServer Condition="'$(SIGN_TIMESTAMPSERVER)' == ''">http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>

--- a/msbuild/zeroc.icebuilder.msbuild.cpp.targets
+++ b/msbuild/zeroc.icebuilder.msbuild.cpp.targets
@@ -101,9 +101,18 @@
             running the SliceCompile target so that the Visual Studio extension has a chance to add the items to the project in
             a persistent way. If the extension is not enabled or we are building from the command line we just add the
             missing items in a transient way.
+
+            First create a property `_SliceCompileGeneratedItems` to hold the paths of all generated items, then we
+            create a ItemGroup to add a ClCompile item for each generated item that is not part of the project. Using an
+            intermediate property for the ClCompile Include avoids _SliceCompile item metadata being copied to the
+            generated ClCompile item.
         -->
+        <CreateProperty Value="$([System.IO.Path]::GetFullPath('%(_SliceCompile.OutputDir)\%(_SliceCompile.Filename).%(_SliceCompile.SourceExt)'))">
+            <Output TaskParameter="Value" PropertyName="_SliceCompileGeneratedItems" />
+        </CreateProperty>
+
         <ItemGroup>
-            <ClCompile Include="@(_SliceCompile->'%(OutputDir)\%(Filename).%(SourceExt)')"
+            <ClCompile Include="$(_SliceCompileGeneratedItems)"
                        Exclude="@(ClCompile->'%(FullPath)');@(ClCompile->'%(Identity)')" />
         </ItemGroup>
 

--- a/msbuild/zeroc.icebuilder.msbuild.csharp.targets
+++ b/msbuild/zeroc.icebuilder.msbuild.csharp.targets
@@ -87,9 +87,19 @@
             running the SliceCompile target so that the Visual Studio extension has a chance to add these items to the project in
             a persistent way. If the extension is not enabled or we are building from the command line we just add the
             missing items in a transient way.
+
+            First create a property `_SliceCompileGeneratedItems` to hold the paths of all generated items, then we
+            create a ItemGroup to add a Compile item for each generated item that is not part of the project. Using an
+            intermediate property for the Compile Include avoids _SliceCompile item metadata being copied to the
+            generated Compile item.
         -->
+
+        <CreateProperty Value="$([System.IO.Path]::GetFullPath('%(_SliceCompile.OutputDir)\%(_SliceCompile.Filename).cs'))">
+            <Output TaskParameter="Value" PropertyName="_SliceCompileGeneratedItems" />
+        </CreateProperty>
+
         <ItemGroup>
-            <Compile Include="@(_SliceCompile->'%(OutputDir)\%(Filename).cs')"
+            <Compile Include="$(_SliceCompileGeneratedItems)"
                      Exclude="@(Compile->'%(FullPath)');@(Compile->'%(Identity)')" />
         </ItemGroup>
     </Target>

--- a/msbuild/zeroc.icebuilder.msbuild.nuspec
+++ b/msbuild/zeroc.icebuilder.msbuild.nuspec
@@ -3,7 +3,7 @@
     <metadata>
         <id>zeroc.icebuilder.msbuild</id>
         <title>ZeroC Ice Builder for MSBuild</title>
-        <version>5.0.4</version>
+        <version>5.0.5</version>
         <authors>ZeroC</authors>
         <licenseUrl>https://raw.githubusercontent.com/zeroc-ice/ice-builder-msbuild/master/LICENSE.txt</licenseUrl>
         <projectUrl>https://github.com/zeroc-ice/ice-builder-msbuild</projectUrl>


### PR DESCRIPTION
This PR fix to interrelated bugs with the builder:

* Items that are automatically added by the SliceCompile task, because they are not part of the project, inherit the SliceCompile options instead of the options specified for the generated item `ClCompile` in C++ projects or `Compile` in C# projects
* Because the automatic items include attribute directly used the OutputDir property, the excludes attribute only matched files in certain circumstances.